### PR TITLE
Add idler script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          name: Install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt && pip install pytest
+      - save_cache:
+          key: deps-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6.4-alpine
+
+MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
+
+WORKDIR /home/idler
+
+ADD requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+ADD idler.py idler.py
+
+CMD ["python", "idler.py"]

--- a/idler.py
+++ b/idler.py
@@ -1,0 +1,76 @@
+"""
+Checks all RStudio deployments and idles those matching criteria
+"""
+
+from datetime import datetime, timezone
+import logging
+
+from kubernetes import client, config
+
+
+IDLED = 'idled'
+IDLED_AT = 'mojanalytics.xyz/idled-at'
+
+
+api = None
+log = logging.getLogger(__name__)
+
+
+def idle_deployments():
+    for deployment in eligible_deployments():
+        idle(deployment)
+
+
+def eligible_deployments():
+    deployments = api.list_deployment_for_all_namespaces(
+        label_selector=f'!{IDLED},app=rstudio')
+    return filter(eligible, deployments.items)
+
+
+def eligible(deployment):
+    return True
+
+
+def idle(deployment):
+    mark_idled(deployment)
+    # redirect_to_unidler(deployment)
+    # zero_replicas(deployment)
+    write_changes(deployment)
+    log.debug(
+        f'{deployment.metadata.name} '
+        f'in namespace {deployment.metadata.namespace} '
+        f'idled')
+
+
+def mark_idled(deployment):
+    timestamp = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    deployment.metadata.labels[IDLED] = 'true'
+    deployment.metadata.annotations[IDLED_AT] = (
+        f'{timestamp},{deployment.spec.replicas}')
+
+
+def redirect_to_unidler(deployment):
+    pass
+
+
+def zero_replicas(deployment):
+    deployment.spec.replicas = 0
+
+
+def write_changes(deployment):
+    api.patch_namespaced_deployment(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        deployment
+    )
+
+
+if __name__ == '__main__':
+    try:
+        config.load_incluster_config()
+    except:
+        config.load_kube_config()
+
+    api = client.AppsV1beta1Api()
+
+    idle_deployments()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes==4.0.0

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+from unittest import mock
+
+import pytest
+
+import idler
+from idler import IDLED, IDLED_AT
+
+
+@pytest.yield_fixture
+def current_time():
+    dt = mock.MagicMock()
+    now = datetime(2018, 2, 7, 11, 44, 20, tzinfo=timezone.utc)
+    dt.now.return_value = now
+    with mock.patch('idler.datetime', dt):
+        yield now
+
+
+@pytest.fixture
+def deployment():
+    deployment = mock.MagicMock()
+    deployment.metadata.annotations = {}
+    deployment.metadata.labels = {}
+    deployment.spec.replicas = expected_replicas = 2
+    return deployment
+
+
+@pytest.yield_fixture
+def api(deployment):
+    api = mock.MagicMock()
+    api.list_deployment_for_all_namespaces.return_value.items = [
+        deployment,
+    ]
+    with mock.patch('idler.api', api):
+        yield api
+
+
+def test_eligible(deployment):
+    assert idler.eligible(deployment)
+
+
+def test_eligible_deployments(api):
+    deployments = idler.eligible_deployments()
+    api.list_deployment_for_all_namespaces.assert_called_with(
+        label_selector=f'!{IDLED},app=rstudio')
+    assert len(list(deployments)) > 0
+
+
+def test_mark_idled(deployment, current_time):
+    expected_replicas = deployment.spec.replicas
+
+    idler.mark_idled(deployment)
+
+    assert IDLED in deployment.metadata.labels
+    assert IDLED_AT in deployment.metadata.annotations
+    timestamp, replicas = deployment.metadata.annotations[IDLED_AT].split(',')
+    assert int(replicas) == expected_replicas
+    assert timestamp == current_time.isoformat(timespec='seconds')
+
+
+def test_redirect_to_unidler():
+    pass
+
+
+def test_zero_replicas(deployment):
+    idler.zero_replicas(deployment)
+
+    assert deployment.spec.replicas == 0
+
+
+def test_write_changes(api, deployment):
+    idler.write_changes(deployment)
+
+    api.patch_namespaced_deployment.assert_called_with(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        deployment
+    )


### PR DESCRIPTION
* Fetches all deployments across all namespaces which match specified criteria (currently non-idled RStudio deployments, check for activity to be implemented later)
* Adds a 'idle' label and an 'idled-at' annotation, recording time of idling and number of replicas.
* (not yet implemented) Redirects ingress to unidler proxy
* Reduces deployment replicas to 0 (currently disabled while testing in cluster)

See [Trello #615](https://trello.com/c/35MZglGh)