### PR TITLE
Implement ingress redirection to Unidler proxy

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -13,7 +13,6 @@ IDLED_AT = 'mojanalytics.xyz/idled-at'
 UNIDLER = 'unidler'
 
 
-api = None
 log = logging.getLogger(__name__)
 
 
@@ -23,7 +22,7 @@ def idle_deployments():
 
 
 def eligible_deployments():
-    deployments = api.list_deployment_for_all_namespaces(
+    deployments = client.AppsV1beta1Api().list_deployment_for_all_namespaces(
         label_selector=f'!{IDLED},app=rstudio')
     return filter(eligible, deployments.items)
 
@@ -57,7 +56,7 @@ def redirect_to_unidler(deployment):
 
 
 def get_deployment_ingress(deployment):
-    return api.read_namespaced_ingress(
+    return client.ExtensionsV1beta1Api().read_namespaced_ingress(
         deployment.metadata.name,
         deployment.metadata.namespace)
 
@@ -67,7 +66,7 @@ def set_unidler_backend(ingress):
 
 
 def write_ingress_changes(ingress):
-    api.patch_namespaced_ingress(
+    client.ExtensionsV1beta1Api().patch_namespaced_ingress(
         ingress.metadata.name,
         ingress.metadata.namespace,
         ingress)
@@ -78,7 +77,7 @@ def zero_replicas(deployment):
 
 
 def write_changes(deployment):
-    api.patch_namespaced_deployment(
+    client.AppsV1beta1Api().patch_namespaced_deployment(
         deployment.metadata.name,
         deployment.metadata.namespace,
         deployment)
@@ -89,7 +88,5 @@ if __name__ == '__main__':
         config.load_incluster_config()
     except:
         config.load_kube_config()
-
-    api = client.AppsV1beta1Api()
 
     idle_deployments()

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -26,21 +26,23 @@ def deployment():
 
 
 @pytest.yield_fixture
-def api(deployment):
-    api = mock.MagicMock()
-    api.list_deployment_for_all_namespaces.return_value.items = [
+def client(deployment):
+    client = mock.MagicMock()
+    apps_api = client.AppsV1beta1Api.return_value
+    apps_api.list_deployment_for_all_namespaces.return_value.items = [
         deployment,
     ]
-    with mock.patch('idler.api', api):
-        yield api
+    with mock.patch('idler.client', client):
+        yield client
 
 
 def test_eligible(deployment):
     assert idler.eligible(deployment)
 
 
-def test_eligible_deployments(api):
+def test_eligible_deployments(client):
     deployments = idler.eligible_deployments()
+    api = client.AppsV1beta1Api.return_value
     api.list_deployment_for_all_namespaces.assert_called_with(
         label_selector=f'!{IDLED},app=rstudio')
     assert len(list(deployments)) > 0
@@ -58,9 +60,10 @@ def test_mark_idled(deployment, current_time):
     assert timestamp == current_time.isoformat(timespec='seconds')
 
 
-def test_get_deployment_ingress(api, deployment):
+def test_get_deployment_ingress(client, deployment):
     idler.get_deployment_ingress(deployment)
 
+    api = client.ExtensionsV1beta1Api.return_value
     api.read_namespaced_ingress.assert_called_with(
         deployment.metadata.name,
         deployment.metadata.namespace)
@@ -76,11 +79,12 @@ def test_set_unidler_backend():
     assert ingress.spec.rules[0].http.paths[0].backend.serviceName == UNIDLER
 
 
-def test_write_ingress_changes(api):
+def test_write_ingress_changes(client):
     ingress = mock.MagicMock()
 
     idler.write_ingress_changes(ingress)
 
+    api = client.ExtensionsV1beta1Api.return_value
     api.patch_namespaced_ingress.assert_called_with(
         ingress.metadata.name,
         ingress.metadata.namespace,
@@ -93,9 +97,10 @@ def test_zero_replicas(deployment):
     assert deployment.spec.replicas == 0
 
 
-def test_write_changes(api, deployment):
+def test_write_changes(client, deployment):
     idler.write_changes(deployment)
 
+    api = client.AppsV1beta1Api.return_value
     api.patch_namespaced_deployment.assert_called_with(
         deployment.metadata.name,
         deployment.metadata.namespace,


### PR DESCRIPTION
* When a deployment is idled, modify its ingress to direct traffic to the Unidler proxy
* (Not implemented here) When the proxy receives a request, it will restore the deployment replicas and remove the idle annotation and label

There is an assumption here that the ingress does not specify a default backend, but instead has a single rule.
Another assumption is that the deployment service name is the same as the deployment name, so does not need to be recorded for use by the Unidler when restoring the original ingress configuration.