### PR TITLE
Enable overriding label selector with env var

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -4,6 +4,7 @@ Checks all RStudio deployments and idles those matching criteria
 
 from datetime import datetime, timezone
 import logging
+import os
 
 from kubernetes import client, config
 
@@ -22,8 +23,10 @@ def idle_deployments():
 
 
 def eligible_deployments():
+    label_selector = os.environ.get('LABEL_SELECTOR', 'app=rstudio')
+    label_selector = f',{label_selector}' if label_selector else ''
     deployments = client.AppsV1beta1Api().list_deployment_for_all_namespaces(
-        label_selector=f'!{IDLED},app=rstudio')
+        label_selector=f'!{IDLED}{label_selector}')
     return filter(eligible, deployments.items)
 
 

--- a/idler.py
+++ b/idler.py
@@ -1,5 +1,10 @@
 """
-Checks all RStudio deployments and idles those matching criteria
+Checks all RStudio deployments and idles those matching a kubernetes label
+selector.
+The label selector can be overridden by setting the LABEL_SELECTOR environment
+variable.
+See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+for label selector syntax.
 """
 
 from datetime import datetime, timezone
@@ -25,13 +30,8 @@ def idle_deployments():
 def eligible_deployments():
     label_selector = os.environ.get('LABEL_SELECTOR', 'app=rstudio')
     label_selector = f',{label_selector}' if label_selector else ''
-    deployments = client.AppsV1beta1Api().list_deployment_for_all_namespaces(
-        label_selector=f'!{IDLED}{label_selector}')
-    return filter(eligible, deployments.items)
-
-
-def eligible(deployment):
-    return True
+    return client.AppsV1beta1Api().list_deployment_for_all_namespaces(
+        label_selector=f'!{IDLED}{label_selector}').items
 
 
 def idle(deployment):

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -44,10 +44,6 @@ def env():
         yield env
 
 
-def test_eligible(deployment, env):
-    assert idler.eligible(deployment)
-
-
 def test_eligible_deployments(client, env):
     deployments = idler.eligible_deployments()
     api = client.AppsV1beta1Api.return_value


### PR DESCRIPTION
* Allow overriding the label selector with an environment variable `LABEL_SELECTOR`
* Takes a string in the documented format: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
* Always prefixes with `!mojanalytics.xyz/idled` and default value is `!mojanalytics.xyz/idled,app=rstudio`, which gets all rstudio deployments which have been idled

This is mainly for testing purposes, to restrict idling to a subset of deployments (eg: mine).