### PR TITLE
Enable deployment redirection to unidler proxy

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -7,36 +7,63 @@ See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 for label selector syntax.
 """
 
+import contextlib
 from datetime import datetime, timezone
 import logging
 import os
 
 from kubernetes import client, config
+from kubernetes.client.models import (
+    V1beta1HTTPIngressPath,
+    V1beta1HTTPIngressRuleValue,
+    V1beta1IngressBackend,
+    V1beta1IngressRule,
+)
 
 
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
+INGRESS_CLASS = 'kubernetes.io/ingress.class'
 UNIDLER = 'unidler'
 
 
 log = logging.getLogger(__name__)
+ingress_lookup = {}
 
 
 def idle_deployments():
-    for deployment in eligible_deployments():
-        idle(deployment)
+    build_ingress_lookup()
+
+    with ingress(UNIDLER, 'default') as unidler:
+        for deployment in eligible_deployments():
+            idle(deployment, unidler)
+
+
+@contextlib.contextmanager
+def ingress(name, namespace):
+    ingress = ingress_lookup[(name, namespace)]
+    yield ingress
+    write_ingress_changes(ingress)
+
+
+def build_ingress_lookup():
+    ingresses = client.ExtensionsV1beta1Api().list_ingress_for_all_namespaces()
+    for i in ingresses.items:
+        ingress_lookup[(i.metadata.name, i.metadata.namespace)] = i
 
 
 def eligible_deployments():
     label_selector = os.environ.get('LABEL_SELECTOR', 'app=rstudio')
-    label_selector = f',{label_selector}' if label_selector else ''
+    if label_selector:
+        label_selector = ',' + label_selector
+
     return client.AppsV1beta1Api().list_deployment_for_all_namespaces(
         label_selector=f'!{IDLED}{label_selector}').items
 
 
-def idle(deployment):
+def idle(deployment, unidler):
     mark_idled(deployment)
-    redirect_to_unidler(deployment)
+    redirect_to_unidler(deployment, unidler)
     zero_replicas(deployment)
     write_changes(deployment)
     log.debug(
@@ -52,20 +79,30 @@ def mark_idled(deployment):
         f'{timestamp},{deployment.spec.replicas}')
 
 
-def redirect_to_unidler(deployment):
-    ingress = get_deployment_ingress(deployment)
-    set_unidler_backend(ingress)
-    write_ingress_changes(ingress)
+def redirect_to_unidler(deployment, unidler):
+    name = deployment.metadata.name
+    namespace = deployment.metadata.namespace
+
+    with ingress(name, namespace) as ing:
+        disable_ingress(ing)
+        add_host_rule(unidler, ing)
 
 
-def get_deployment_ingress(deployment):
-    return client.ExtensionsV1beta1Api().read_namespaced_ingress(
-        deployment.metadata.name,
-        deployment.metadata.namespace)
+def disable_ingress(ingress):
+    ingress.metadata.annotations[INGRESS_CLASS] = 'disabled'
 
 
-def set_unidler_backend(ingress):
-    ingress.spec.rules[0].http.paths[0].backend.serviceName = UNIDLER
+def add_host_rule(unidler, ingress):
+    unidler.spec.rules.append(
+        V1beta1IngressRule(
+            # XXX assumption: ingress has rules and first one is relevant
+            host=ingress.spec.rules[0].host,
+            http=V1beta1HTTPIngressRuleValue(
+                paths=[
+                    V1beta1HTTPIngressPath(
+                        backend=V1beta1IngressBackend(
+                            service_name=UNIDLER,
+                            service_port=80))])))
 
 
 def write_ingress_changes(ingress):


### PR DESCRIPTION
The previous implementation attempted to modify the deployment ingress to point to the unidler proxy, which failed because the unidler is in a different namespace and ingresses cannot route across namespaces.

This implementation uses the following process:

1. Disable the deployment ingress by changing the `kubernetes.io/ingress.class` annotation from `nginx` to `disabled`. This removes the deployment ingress configuration from the nginx ingress controller.
2. Add a rule to the unidler ingress (in the `default` namespace) for the deployment's hostname, which will cause traffic for the deployment to be routed instead to the unidler proxy.