### PR TITLE
Only idle if average CPU usage of deployment pods is lower than a certain threshold

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -23,14 +23,23 @@ from kubernetes.client.models import (
 import metrics_api
 
 
+log = logging.getLogger(__name__)
+
+
 ACTIVE_INSTANCE_CPU_PERCENTAGE = 90
+try:
+    ACTIVE_INSTANCE_CPU_PERCENTAGE = int(os.environ.get(
+        'RSTUDIO_ACTIVITY_CPU_THRESHOLD', 90))
+except ValueError:
+    log.warning(
+        'Invalid value for RSTUDIO_ACTIVITY_CPU_THRESHOLD, using default')
+
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
 INGRESS_CLASS = 'kubernetes.io/ingress.class'
 UNIDLER = 'unidler'
 
 
-log = logging.getLogger(__name__)
 ingress_lookup = {}
 metrics_lookup = {}
 

--- a/idler.py
+++ b/idler.py
@@ -20,7 +20,10 @@ from kubernetes.client.models import (
     V1beta1IngressRule,
 )
 
+import metrics_api
 
+
+ACTIVE_INSTANCE_CPU_PERCENTAGE = 90
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
 INGRESS_CLASS = 'kubernetes.io/ingress.class'
@@ -29,14 +32,18 @@ UNIDLER = 'unidler'
 
 log = logging.getLogger(__name__)
 ingress_lookup = {}
+metrics_lookup = {}
 
 
 def idle_deployments():
     build_ingress_lookup()
 
     with ingress(UNIDLER, 'default') as unidler:
+        build_metrics_lookup()
+
         for deployment in eligible_deployments():
-            idle(deployment, unidler)
+            if should_idle(deployment):
+                idle(deployment, unidler)
 
 
 @contextlib.contextmanager
@@ -52,13 +59,46 @@ def build_ingress_lookup():
         ingress_lookup[(i.metadata.name, i.metadata.namespace)] = i
 
 
+def build_metrics_lookup():
+    metrics = client.MetricsV1beta1Api().list_pod_metrics_for_all_namespaces(
+        label_selector=f'!{IDLED},{label_selector()}')
+    for i in metrics.items:
+        metrics_lookup[(i.metadata.name, i.metadata.namespace)] = i
+
+
 def eligible_deployments():
+    return client.AppsV1beta1Api().list_deployment_for_all_namespaces(
+        label_selector=f'!{IDLED}{label_selector()}').items
+
+
+def label_selector():
     label_selector = os.environ.get('LABEL_SELECTOR', 'app=rstudio')
     if label_selector:
         label_selector = ',' + label_selector
+    return label_selector
 
-    return client.AppsV1beta1Api().list_deployment_for_all_namespaces(
-        label_selector=f'!{IDLED}{label_selector}').items
+
+def should_idle(deployment):
+    usage = avg_cpu_percent(deployment)
+    if usage > ACTIVE_INSTANCE_CPU_PERCENTAGE:
+        logging.info(
+            f'Not idling {deployment.metadata.name} '
+            f'in {deployment.metadata.namespace} as CPU at {usage}%')
+        return False
+
+    return True
+
+
+def avg_cpu_percent(deployment):
+    metrics = metrics_lookup[
+        (deployment.metadata.name, deployment.metadata.namespace)]
+
+    usage = 0
+
+    for container in metrics.containers:
+        usage += int(container.usage['cpu'].strip('m'), 10)
+
+    return usage / 10
 
 
 def idle(deployment, unidler):

--- a/idler.py
+++ b/idler.py
@@ -163,10 +163,14 @@ def write_changes(deployment):
         deployment)
 
 
-if __name__ == '__main__':
+def load_kube_config():
     try:
         config.load_incluster_config()
     except:
+        import k8s_oidc
         config.load_kube_config()
 
+
+if __name__ == '__main__':
+    load_kube_config()
     idle_deployments()

--- a/idler.py
+++ b/idler.py
@@ -105,8 +105,10 @@ def avg_cpu_percent(deployment):
     usage = 0
 
     for container in metrics.containers:
+        # cpu usage is reported in millicpus with suffix 'm'
         usage += int(container.usage['cpu'].strip('m'), 10)
 
+    # convert millicpus to cpu percentage
     return usage / 10
 
 

--- a/k8s_oidc.py
+++ b/k8s_oidc.py
@@ -1,0 +1,272 @@
+import base64
+import datetime
+import json
+import tempfile
+
+import google.auth
+import google.auth.transport.requests
+import oauthlib.oauth2
+import urllib3
+from requests_oauthlib import OAuth2Session
+from six import PY3
+
+import kubernetes
+from kubernetes.client import ApiClient, Configuration
+from kubernetes.config.dateutil import UTC, format_rfc3339
+from kubernetes.config.kube_config import (
+    ConfigNode,
+    FileOrData,
+    _is_expired,
+)
+
+
+class KubeConfigLoader(object):
+
+    def __init__(self, config_dict, active_context=None,
+                 get_google_credentials=None,
+                 config_base_path="",
+                 config_persister=None):
+        self._config = ConfigNode('kube-config', config_dict)
+        self._current_context = None
+        self._user = None
+        self._cluster = None
+        self.set_active_context(active_context)
+        self._config_base_path = config_base_path
+        self._config_persister = config_persister
+
+        def _refresh_credentials():
+            credentials, project_id = google.auth.default(
+                scopes=['https://www.googleapis.com/auth/cloud-platform']
+            )
+            request = google.auth.transport.requests.Request()
+            credentials.refresh(request)
+            return credentials
+
+        if get_google_credentials:
+            self._get_google_credentials = get_google_credentials
+        else:
+            self._get_google_credentials = _refresh_credentials
+
+    def set_active_context(self, context_name=None):
+        if context_name is None:
+            context_name = self._config['current-context']
+        self._current_context = self._config['contexts'].get_with_name(
+            context_name)
+        if (self._current_context['context'].safe_get('user') and
+                self._config.safe_get('users')):
+            user = self._config['users'].get_with_name(
+                self._current_context['context']['user'], safe=True)
+            if user:
+                self._user = user['user']
+            else:
+                self._user = None
+        else:
+            self._user = None
+        self._cluster = self._config['clusters'].get_with_name(
+            self._current_context['context']['cluster'])['cluster']
+
+    def _load_authentication(self):
+        """Read authentication from kube-config user section if exists.
+
+        This function goes through various authentication methods in user
+        section of kube-config and stops if it finds a valid authentication
+        method. The order of authentication methods is:
+
+            1. GCP auth-provider
+            2. token_data
+            3. token field (point to a token file)
+            4. username/password
+            4. oidc auth-provider
+            5. username/password
+        """
+        if not self._user:
+            return
+        if self._load_gcp_token():
+            return
+        if self._load_user_token():
+            return
+        if self._load_oid_token():
+            return
+        self._load_user_pass_token()
+
+    def _load_gcp_token(self):
+        if 'auth-provider' not in self._user:
+            return
+        provider = self._user['auth-provider']
+        if 'name' not in provider:
+            return
+        if provider['name'] != 'gcp':
+            return
+
+        if (('config' not in provider) or
+                ('access-token' not in provider['config']) or
+                ('expiry' in provider['config'] and
+                 _is_expired(provider['config']['expiry']))):
+            # token is not available or expired, refresh it
+            self._refresh_gcp_token()
+
+        self.token = "Bearer %s" % provider['config']['access-token']
+        return self.token
+
+    def _refresh_gcp_token(self):
+        if 'config' not in self._user['auth-provider']:
+            self._user['auth-provider'].value['config'] = {}
+        provider = self._user['auth-provider']['config']
+        credentials = self._get_google_credentials()
+        provider.value['access-token'] = credentials.token
+        provider.value['expiry'] = format_rfc3339(credentials.expiry)
+        if self._config_persister:
+            self._config_persister(self._config.value)
+
+    def _load_oid_token(self):
+        if 'auth-provider' not in self._user:
+            return
+        provider = self._user['auth-provider']
+
+        if 'name' not in provider or 'config' not in provider:
+            return
+
+        if provider['name'] != 'oidc':
+            return
+
+        parts = provider['config']['id-token'].split('.')
+
+        if len(parts) != 3:  # Not a valid JWT
+            return None
+
+        missing_padding = len(parts[1]) % 4
+        if missing_padding != 0:
+            parts[1] += '=' * (4 - missing_padding)
+
+        if PY3:
+            jwt_attributes = json.loads(
+                base64.b64decode(parts[1]).decode('utf-8')
+            )
+        else:
+            jwt_attributes = json.loads(
+                base64.b64decode(parts[1] + "==")
+            )
+
+        expire = jwt_attributes.get('exp')
+
+        if ((expire is not None) and
+            (_is_expired(datetime.datetime.fromtimestamp(expire,
+                                                         tz=UTC)))):
+            self._refresh_oidc(provider)
+
+            if self._config_persister:
+                self._config_persister(self._config.value)
+
+        self.token = "Bearer %s" % provider['config']['id-token']
+
+        return self.token
+
+    def _refresh_oidc(self, provider):
+        ca_cert = tempfile.NamedTemporaryFile(delete=True)
+
+        if PY3:
+            cert = base64.b64decode(
+                provider['config']['idp-certificate-authority-data']
+            ).decode('utf-8')
+        else:
+            cert = base64.b64decode(
+                provider['config']['idp-certificate-authority-data'] + "=="
+            )
+
+        with open(ca_cert.name, 'w') as fh:
+            fh.write(cert)
+
+        config = Configuration()
+        config.ssl_ca_cert = ca_cert.name
+
+        client = ApiClient(configuration=config)
+
+        response = client.request(
+            method="GET",
+            url="%s/.well-known/openid-configuration"
+            % provider['config']['idp-issuer-url']
+        )
+
+        if response.status != 200:
+            return
+
+        response = json.loads(response.data)
+
+        request = OAuth2Session(
+            client_id=provider['config']['client-id'],
+            token=provider['config']['refresh-token'],
+            auto_refresh_kwargs={
+                'client_id': provider['config']['client-id'],
+                'client_secret': provider['config']['client-secret']
+            },
+            auto_refresh_url=response['token_endpoint']
+        )
+
+        try:
+            refresh = request.refresh_token(
+                token_url=response['token_endpoint'],
+                refresh_token=provider['config']['refresh-token'],
+                auth=(provider['config']['client-id'],
+                      provider['config']['client-secret']),
+                verify=ca_cert.name
+            )
+        except oauthlib.oauth2.rfc6749.errors.InvalidClientIdError:
+            return
+
+        provider['config'].value['id-token'] = refresh['id_token']
+        provider['config'].value['refresh-token'] = refresh['refresh_token']
+
+    def _load_user_token(self):
+        token = FileOrData(
+            self._user, 'tokenFile', 'token',
+            file_base_path=self._config_base_path,
+            base64_file_content=False).as_data()
+        if token:
+            self.token = "Bearer %s" % token
+            return True
+
+    def _load_user_pass_token(self):
+        if 'username' in self._user and 'password' in self._user:
+            self.token = urllib3.util.make_headers(
+                basic_auth=(self._user['username'] + ':' +
+                            self._user['password'])).get('authorization')
+            return True
+
+    def _load_cluster_info(self):
+        if 'server' in self._cluster:
+            self.host = self._cluster['server']
+            if self.host.startswith("https"):
+                self.ssl_ca_cert = FileOrData(
+                    self._cluster, 'certificate-authority',
+                    file_base_path=self._config_base_path).as_file()
+                self.cert_file = FileOrData(
+                    self._user, 'client-certificate',
+                    file_base_path=self._config_base_path).as_file()
+                self.key_file = FileOrData(
+                    self._user, 'client-key',
+                    file_base_path=self._config_base_path).as_file()
+        if 'insecure-skip-tls-verify' in self._cluster:
+            self.verify_ssl = not self._cluster['insecure-skip-tls-verify']
+
+    def _set_config(self, client_configuration):
+        if 'token' in self.__dict__:
+            client_configuration.api_key['authorization'] = self.token
+        # copy these keys directly from self to configuration object
+        keys = ['host', 'ssl_ca_cert', 'cert_file', 'key_file', 'verify_ssl']
+        for key in keys:
+            if key in self.__dict__:
+                setattr(client_configuration, key, getattr(self, key))
+
+    def load_and_set(self, client_configuration):
+        self._load_authentication()
+        self._load_cluster_info()
+        self._set_config(client_configuration)
+
+    def list_contexts(self):
+        return [context.value for context in self._config['contexts']]
+
+    @property
+    def current_context(self):
+        return self._current_context.value
+
+kubernetes.config.kube_config.KubeConfigLoader = KubeConfigLoader

--- a/metrics_api.py
+++ b/metrics_api.py
@@ -1,0 +1,258 @@
+from pprint import pformat
+
+from six import iteritems
+
+import kubernetes
+from kubernetes.client.api_client import ApiClient
+
+
+class MetricsV1beta1Api(object):
+
+    def __init__(self, api_client=None):
+        if api_client is None:
+            api_client = ApiClient()
+        self.api_client = api_client
+
+    def list_pod_metrics_for_all_namespaces(self, **kwargs):
+        kwargs['_return_http_data_only'] = True
+        if kwargs.get('async'):
+            return self.list_pod_metrics_for_all_namespaces_with_http_info(
+                **kwargs)
+        else:
+            (data) = self.list_pod_metrics_for_all_namespaces_with_http_info(
+                **kwargs)
+            return data
+
+    def list_pod_metrics_for_all_namespaces_with_http_info(self, **kwargs):
+        collection_formats = {}
+
+        path_params = {}
+
+        query_params = []
+        if '_continue' in kwargs:
+            query_params.append(('continue', kwargs['_continue']))
+        if 'label_selector' in kwargs:
+            query_params.append(('labelSelector', kwargs['label_selector']))
+
+        form_params = []
+        local_var_files = {}
+        body_params = None
+
+        header_params = {
+            'Accept': self.api_client.select_header_accept([
+                'application/json',
+                'application/yaml',
+                'application/vnd.kubernetes.protobuf',
+                'application/json;stream=watch',
+                'application/vnd.kubernetes.protobuf;stream=watch']),
+            'Content-Type': self.api_client.select_header_content_type([
+                '*/*']),
+        }
+        auth_settings = ['BearerToken']
+
+        return self.api_client.call_api(
+            f'/apis/metrics.k8s.io/v1beta1/pods',
+            'GET',
+            path_params,
+            query_params,
+            header_params,
+            body=body_params,
+            post_params=form_params,
+            files=local_var_files,
+            response_type='MetricsV1beta1PodMetricsList',
+            auth_settings=auth_settings,
+            async=kwargs.get('async'),
+            _return_http_data_only=kwargs.get('_return_http_data_only'),
+            _preload_content=kwargs.get('_preload_content', True),
+            _request_timeout=kwargs.get('_request_timeout'),
+            collection_formats=collection_formats)
+
+
+kubernetes.client.apis.MetricsV1beta1Api = MetricsV1beta1Api
+kubernetes.client.MetricsV1beta1Api = MetricsV1beta1Api
+
+
+class MetricsV1beta1PodMetricsList(object):
+    swagger_types = {
+        'api_version': 'str',
+        'items': 'list[MetricsV1beta1PodMetrics]',
+        'kind': 'str',
+        'metadata': 'V1ListMeta'
+    }
+
+    attribute_map = {
+        'api_version': 'apiVersion',
+        'items': 'items',
+        'kind': 'kind',
+        'metadata': 'metadata'
+    }
+
+    def __init__(self, api_version=None, items=None, kind=None, metadata=None):
+        self.api_version = api_version
+        self.items = items
+        self.kind = kind
+        self.metadata = metadata
+        self.discriminator = None
+
+    def to_dict(self):
+        result = {}
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
+                    value
+                ))
+            elif hasattr(value, 'to_dict'):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], 'to_dict') else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        return pformat(self.to_dict())
+
+    def __repr__(self):
+        return self.to_str()
+
+    def __eq__(self, other):
+        if not isinstance(other, MetricsV1beta1PodMetricsList):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other
+
+
+kubernetes.client.models.MetricsV1beta1PodMetricsList = \
+    MetricsV1beta1PodMetricsList
+kubernetes.client.MetricsV1beta1PodMetricsList = MetricsV1beta1PodMetricsList
+
+
+class MetricsV1beta1PodMetrics(object):
+    swagger_types = {
+        'containers': 'list[MetricsV1beta1ContainerMetrics]',
+        'metadata': 'V1ObjectMeta',
+        'timestamp': 'datetime',
+        'window': 'str',
+    }
+
+    attribute_map = {
+        'containers': 'containers',
+        'metadata': 'metadata',
+        'timestamp': 'timestamp',
+        'window': 'window',
+    }
+
+    def __init__(self, containers=None, metadata=None, timestamp=None, window=None):
+        self.containers = containers
+        self.metadata = metadata
+        self.timestamp = timestamp
+        self.window = window
+        self.discriminator = None
+
+    def to_dict(self):
+        result = {}
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
+                    value
+                ))
+            elif hasattr(value, 'to_dict'):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], 'to_dict') else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        return pformat(self.to_dict())
+
+    def __repr__(self):
+        return self.to_str()
+
+    def __eq__(self, other):
+        if not isinstance(other, MetricsV1beta1PodMetrics):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other
+
+kubernetes.client.models.MetricsV1beta1PodMetrics = MetricsV1beta1PodMetrics
+kubernetes.client.MetricsV1beta1PodMetrics = MetricsV1beta1PodMetrics
+
+
+class MetricsV1beta1ContainerMetrics(object):
+    swagger_types = {
+        'name': 'str',
+        'usage': 'dict(str, str)',
+    }
+
+    attribute_map = {
+        'name': 'name',
+        'usage': 'usage',
+    }
+
+    def __init__(self, name=None, usage=None):
+        self.name = name
+        self.usage = usage
+        self.discriminator = None
+
+    def to_dict(self):
+        result = {}
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
+                    value
+                ))
+            elif hasattr(value, 'to_dict'):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], 'to_dict') else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        return pformat(self.to_dict())
+
+    def __repr__(self):
+        return self.to_str()
+
+    def __eq__(self, other):
+        if not isinstance(other, MetricsV1beta1ContainerMetrics):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other
+
+kubernetes.client.models.MetricsV1beta1ContainerMetrics = MetricsV1beta1ContainerMetrics
+kubernetes.client.MetricsV1beta1ContainerMetrics = MetricsV1beta1ContainerMetrics
+

--- a/metrics_api.py
+++ b/metrics_api.py
@@ -72,7 +72,47 @@ kubernetes.client.apis.MetricsV1beta1Api = MetricsV1beta1Api
 kubernetes.client.MetricsV1beta1Api = MetricsV1beta1Api
 
 
-class MetricsV1beta1PodMetricsList(object):
+class Model(object):
+
+    def to_dict(self):
+        result = {}
+        for attr, _ in iteritems(self.swagger_types):
+            value = getattr(self, attr)
+            if isinstance(value, list):
+                result[attr] = list(map(
+                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
+                    value
+                ))
+            elif hasattr(value, 'to_dict'):
+                result[attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[attr] = dict(map(
+                    lambda item: (item[0], item[1].to_dict())
+                    if hasattr(item[1], 'to_dict') else item,
+                    value.items()
+                ))
+            else:
+                result[attr] = value
+
+        return result
+
+    def to_str(self):
+        return pformat(self.to_dict())
+
+    def __repr__(self):
+        return self.to_str()
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self == other
+
+
+class MetricsV1beta1PodMetricsList(Model):
     swagger_types = {
         'api_version': 'str',
         'items': 'list[MetricsV1beta1PodMetrics]',
@@ -94,50 +134,13 @@ class MetricsV1beta1PodMetricsList(object):
         self.metadata = metadata
         self.discriminator = None
 
-    def to_dict(self):
-        result = {}
-        for attr, _ in iteritems(self.swagger_types):
-            value = getattr(self, attr)
-            if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
-                    value
-                ))
-            elif hasattr(value, 'to_dict'):
-                result[attr] = value.to_dict()
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], 'to_dict') else item,
-                    value.items()
-                ))
-            else:
-                result[attr] = value
-
-        return result
-
-    def to_str(self):
-        return pformat(self.to_dict())
-
-    def __repr__(self):
-        return self.to_str()
-
-    def __eq__(self, other):
-        if not isinstance(other, MetricsV1beta1PodMetricsList):
-            return False
-
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not self == other
-
 
 kubernetes.client.models.MetricsV1beta1PodMetricsList = \
     MetricsV1beta1PodMetricsList
 kubernetes.client.MetricsV1beta1PodMetricsList = MetricsV1beta1PodMetricsList
 
 
-class MetricsV1beta1PodMetrics(object):
+class MetricsV1beta1PodMetrics(Model):
     swagger_types = {
         'containers': 'list[MetricsV1beta1ContainerMetrics]',
         'metadata': 'V1ObjectMeta',
@@ -159,48 +162,11 @@ class MetricsV1beta1PodMetrics(object):
         self.window = window
         self.discriminator = None
 
-    def to_dict(self):
-        result = {}
-        for attr, _ in iteritems(self.swagger_types):
-            value = getattr(self, attr)
-            if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
-                    value
-                ))
-            elif hasattr(value, 'to_dict'):
-                result[attr] = value.to_dict()
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], 'to_dict') else item,
-                    value.items()
-                ))
-            else:
-                result[attr] = value
-
-        return result
-
-    def to_str(self):
-        return pformat(self.to_dict())
-
-    def __repr__(self):
-        return self.to_str()
-
-    def __eq__(self, other):
-        if not isinstance(other, MetricsV1beta1PodMetrics):
-            return False
-
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not self == other
-
 kubernetes.client.models.MetricsV1beta1PodMetrics = MetricsV1beta1PodMetrics
 kubernetes.client.MetricsV1beta1PodMetrics = MetricsV1beta1PodMetrics
 
 
-class MetricsV1beta1ContainerMetrics(object):
+class MetricsV1beta1ContainerMetrics(Model):
     swagger_types = {
         'name': 'str',
         'usage': 'dict(str, str)',
@@ -216,43 +182,5 @@ class MetricsV1beta1ContainerMetrics(object):
         self.usage = usage
         self.discriminator = None
 
-    def to_dict(self):
-        result = {}
-        for attr, _ in iteritems(self.swagger_types):
-            value = getattr(self, attr)
-            if isinstance(value, list):
-                result[attr] = list(map(
-                    lambda x: x.to_dict() if hasattr(x, 'to_dict') else x,
-                    value
-                ))
-            elif hasattr(value, 'to_dict'):
-                result[attr] = value.to_dict()
-            elif isinstance(value, dict):
-                result[attr] = dict(map(
-                    lambda item: (item[0], item[1].to_dict())
-                    if hasattr(item[1], 'to_dict') else item,
-                    value.items()
-                ))
-            else:
-                result[attr] = value
-
-        return result
-
-    def to_str(self):
-        return pformat(self.to_dict())
-
-    def __repr__(self):
-        return self.to_str()
-
-    def __eq__(self, other):
-        if not isinstance(other, MetricsV1beta1ContainerMetrics):
-            return False
-
-        return self.__dict__ == other.__dict__
-
-    def __ne__(self, other):
-        return not self == other
-
 kubernetes.client.models.MetricsV1beta1ContainerMetrics = MetricsV1beta1ContainerMetrics
 kubernetes.client.MetricsV1beta1ContainerMetrics = MetricsV1beta1ContainerMetrics
-

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -131,11 +131,11 @@ def test_label_selector(client, env, label_selector, expected):
         label_selector=expected)
 
 
-def test_should_idle(deployment, metrics):
+def test_should_idle(deployment, env, metrics):
     assert idler.should_idle(deployment)
 
 
-def test_should_not_idle(deployment):
+def test_should_not_idle(deployment, env):
     with patch('idler.avg_cpu_percent') as cpu:
         cpu.return_value = 100
         assert not idler.should_idle(deployment)

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -80,8 +80,6 @@ def metrics(deployment):
         (deployment.metadata.name, deployment.metadata.namespace): metric,
     }
     with patch('idler.metrics_lookup', cache):
-        print('metrics fixture')
-        print(cache)
         yield cache
 
 
@@ -151,15 +149,7 @@ def test_should_not_idle(deployment):
 ])
 def test_avg_cpu_percent(deployment, metrics, cpu_usage, expected):
     key = (deployment.metadata.name, deployment.metadata.namespace)
-
-    print('test_avg_cpu_percent')
-    print(metrics)
-    print(metrics[key])
     metrics[key] = mock_podmetric(cpu_usage)
-    print('parameter')
-    print(metrics[key])
-    print(metrics[key].containers)
-
     assert idler.avg_cpu_percent(deployment) == expected
 
 

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -63,12 +63,35 @@ def ingress_lookup(deployment, unidler):
         yield lookup
 
 
-def test_idle_deployments(client, deployment, env, ingress_lookup):
+def mock_podmetric(cpu_usage=['0']):
+    metric = MagicMock(name='PodMetrics')
+    metric.containers = []
+    for usage in cpu_usage:
+        container = MagicMock(name='Container')
+        container.usage = {'cpu': usage}
+        metric.containers.append(container)
+    return metric
+
+
+@pytest.yield_fixture
+def metrics(deployment):
+    metric = mock_podmetric()
+    cache = {
+        (deployment.metadata.name, deployment.metadata.namespace): metric,
+    }
+    with patch('idler.metrics_lookup', cache):
+        print('metrics fixture')
+        print(cache)
+        yield cache
+
+
+def test_idle_deployments(client, deployment, env, ingress_lookup, metrics):
     deployment_ingress = ingress_lookup[(
         deployment.metadata.name, deployment.metadata.namespace)]
     unidler_ingress = ingress_lookup[(UNIDLER, 'default')]
     extensions_api = client.ExtensionsV1beta1Api.return_value
     apps_api = client.AppsV1beta1Api.return_value
+    metrics_api = client.MetricsV1beta1Api.return_value
 
     idler.idle_deployments()
 
@@ -86,7 +109,6 @@ def test_idle_deployments(client, deployment, env, ingress_lookup):
         deployment.metadata.name,
         deployment.metadata.namespace,
         deployment)
-
 
 
 def test_eligible_deployments(client, env):
@@ -109,6 +131,36 @@ def test_label_selector(client, env, label_selector, expected):
     api = client.AppsV1beta1Api.return_value
     api.list_deployment_for_all_namespaces.assert_called_with(
         label_selector=expected)
+
+
+def test_should_idle(deployment, metrics):
+    assert idler.should_idle(deployment)
+
+
+def test_should_not_idle(deployment):
+    with patch('idler.avg_cpu_percent') as cpu:
+        cpu.return_value = 100
+        assert not idler.should_idle(deployment)
+
+
+@pytest.mark.parametrize('cpu_usage, expected', [
+    (['0'], 0),
+    (['0', '0'], 0),
+    (['100m', '0'], 10),
+    (['100m', '100m'], 20),
+])
+def test_avg_cpu_percent(deployment, metrics, cpu_usage, expected):
+    key = (deployment.metadata.name, deployment.metadata.namespace)
+
+    print('test_avg_cpu_percent')
+    print(metrics)
+    print(metrics[key])
+    metrics[key] = mock_podmetric(cpu_usage)
+    print('parameter')
+    print(metrics[key])
+    print(metrics[key].containers)
+
+    assert idler.avg_cpu_percent(deployment) == expected
 
 
 def test_mark_idled(deployment, current_time):


### PR DESCRIPTION
*Depends on [`metrics-server`](https://github.com/kubernetes-incubator/metrics-server) being deployed in the cluster*

* Access Kubernetes Resource Metrics API (added by `metrics-server`) to get the total average CPU usage (over the last 1 minute - not configurable, yet) of containers in a deployment's pods, and only idle the deployment if that total is greater than a certain threshold (configurable by the `RSTUDIO_ACTIVITY_CPU_THRESHOLD` env var)
* Add a monkey-patch to the Kubernetes Python client for the Metrics API. Official support should be coming soon, at which time this can be removed. This code is normally generated using Swagger, and I've essentially edited some copy-pasted code from other parts of the Kubernetes client.
* Add a monkey-patch to the Kubernetes Python client for OIDC authentication. Taken from a PR which should be merged in the next release, at which time this can be removed.