### PR TITLE
Ensure idled hostname is in unidler ingress TLS hosts list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,25 @@
-FROM python:3.6.4-alpine
+FROM python:3.6.4-alpine AS base
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
 WORKDIR /home/idler
 
 ADD requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install -U pip && pip install -r requirements.txt
 
 ADD idler.py idler.py
 ADD metrics_api.py metrics_api.py
 
 CMD ["python", "idler.py"]
+
+
+FROM base AS test
+
+RUN pip install pytest
+
+ADD test test
+
+RUN pytest test
+
+
+FROM base

--- a/idler.py
+++ b/idler.py
@@ -186,16 +186,20 @@ def disable_ingress(ingress):
 
 
 def add_host_rule(unidler, ingress):
+    # XXX assumption: ingress has rules and first one is relevant
+    hostname = ingress.spec.rules[0].host
     unidler.spec.rules.append(
         V1beta1IngressRule(
-            # XXX assumption: ingress has rules and first one is relevant
-            host=ingress.spec.rules[0].host,
+            host=hostname,
             http=V1beta1HTTPIngressRuleValue(
                 paths=[
                     V1beta1HTTPIngressPath(
                         backend=V1beta1IngressBackend(
                             service_name=UNIDLER,
                             service_port=80))])))
+    # ensure the host is listed in tls hosts
+    if hostname not in unidler.spec.tls[0].hosts:
+        unidler.spec.tls[0].hosts.append(hostname)
 
 
 def write_ingress_changes(ingress):

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -77,6 +77,8 @@ def unidler():
     unidler.spec.rules = [
         MagicMock(),
     ]
+    unidler.spec.tls = [MagicMock()]
+    unidler.spec.tls[0].hosts = []
     return unidler
 
 
@@ -231,6 +233,7 @@ def test_add_host_rule(deployment, ingress_lookup, unidler):
     assert len(unidler.spec.rules) == 2
     assert unidler.spec.rules[1].host == ingress.spec.rules[0].host
     assert unidler.spec.rules[1].http.paths[0].backend.service_name == UNIDLER
+    assert ingress.spec.rules[0].host in unidler.spec.tls[0].hosts
 
 
 def test_write_ingress_changes(client):


### PR DESCRIPTION
* Add instance hostname to unidler ingress TLS hosts list if not already listed when idling, otherwise the unidler will not accept HTTPS requests and unidling will not work :(