### PR TITLE
Idler + Metrics fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# intellij
+.idea/
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.6.4-alpine AS base
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
 WORKDIR /home/idler
+RUN apk update && apk add --virtual build-dependencies build-base gcc libffi-dev openssl-dev
 
 ADD requirements.txt requirements.txt
 RUN pip install -U pip && pip install -r requirements.txt
@@ -15,11 +16,13 @@ CMD ["python", "idler.py"]
 
 FROM base AS test
 
-RUN pip install pytest
+ADD test/requirements.txt test/
+RUN pip install -r test/requirements.txt
 
 ADD test test
 
 RUN pytest test
 
-
 FROM base
+
+RUN apk del build-dependencies

--- a/idler.py
+++ b/idler.py
@@ -132,9 +132,16 @@ def should_idle(deployment):
     return True
 
 
-def millicpu_to_int(millicpu):
+def core_val_with_unit_to_int(core_val_with_unit: str):
     # millicpus have the 'm' suffix
-    return int(millicpu.strip('m'), 10)
+    if core_val_with_unit.endswith('m'):
+        return int(core_val_with_unit.rstrip('m'), 10)
+    elif core_val_with_unit.endswith('n'):
+        # nanocpus have the 'n' suffix
+        return int(core_val_with_unit.rstrip('n'), 10) / 1000000
+    else:
+        # if the result is 0 then there is no suffix
+        return int(core_val_with_unit, 10)
 
 
 def avg_cpu_percent(deployment):
@@ -147,11 +154,11 @@ def avg_cpu_percent(deployment):
 
     usage = 0
     for container in metrics.containers:
-        usage += millicpu_to_int(container.usage['cpu'])
+        usage += core_val_with_unit_to_int(container.usage['cpu'])
 
     total = 0
     for container in deployment.spec.template.spec.containers:
-        total += millicpu_to_int(container.resources.limits['cpu'])
+        total += core_val_with_unit_to_int(container.resources.limits['cpu'])
 
     return usage / total * 100.0
 

--- a/metrics_api.py
+++ b/metrics_api.py
@@ -61,7 +61,7 @@ class MetricsV1beta1Api(object):
             files=local_var_files,
             response_type='MetricsV1beta1PodMetricsList',
             auth_settings=auth_settings,
-            async=kwargs.get('async'),
+            async_req=kwargs.get('async_req'),
             _return_http_data_only=kwargs.get('_return_http_data_only'),
             _preload_content=kwargs.get('_preload_content', True),
             _request_timeout=kwargs.get('_request_timeout'),

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,2 @@
+pytest==3.8.2
+hypothesis==3.74.0


### PR DESCRIPTION
The metrics api now seems to return CPU usage as nanocores (which is a
millicore * 1000000)

But in some places .e.g cpu limits, k8s still uses millicores. This allows the
idler to handle both formats

This commit also fixes the docker file as the kubernetes dependency v7.0.0 needs
some build dependencies added