### PR TITLE
Lookup Ingress by app label

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -76,9 +76,10 @@ def ingress(name, namespace):
 
 
 def build_ingress_lookup():
-    ingresses = client.ExtensionsV1beta1Api().list_ingress_for_all_namespaces()
+    ingresses = client.ExtensionsV1beta1Api().list_ingress_for_all_namespaces(label_selector='app')
     for i in ingresses.items:
-        ingress_lookup[(i.metadata.name, i.metadata.namespace)] = i
+        if i.metadata.labels and 'app' in i.metadata.labels.keys():
+            ingress_lookup[(i.metadata.labels['app'], i.metadata.namespace)] = i
 
 
 def build_metrics_lookup():
@@ -188,10 +189,10 @@ def mark_idled(deployment):
 
 
 def redirect_to_unidler(deployment, unidler):
-    name = deployment.metadata.name
+    app_name = deployment.metadata.labels['app']
     namespace = deployment.metadata.namespace
 
-    with ingress(name, namespace) as ing:
+    with ingress(app_name, namespace) as ing:
         disable_ingress(ing)
         add_host_rule(unidler, ing)
 

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -108,7 +108,7 @@ def unidler():
 def ingress_lookup(deployment, unidler):
     lookup = {
         (UNIDLER, 'default'): unidler,
-        (deployment.metadata.name, deployment.metadata.namespace): MagicMock(),
+        (deployment.metadata.labels['app'], deployment.metadata.namespace): MagicMock(),
     }
     with patch.dict('idler.ingress_lookup', lookup):
         yield lookup
@@ -147,7 +147,7 @@ def pods_lookup(pod):
 
 def test_idle_deployments(client, deployment, env, ingress_lookup, metrics):
     deployment_ingress = ingress_lookup[(
-        deployment.metadata.name, deployment.metadata.namespace)]
+        deployment.metadata.labels['app'], deployment.metadata.namespace)]
     unidler_ingress = ingress_lookup[(UNIDLER, 'default')]
     extensions_api = client.ExtensionsV1beta1Api.return_value
     apps_api = client.AppsV1beta1Api.return_value
@@ -259,7 +259,7 @@ def test_disable_ingress():
 
 def test_add_host_rule(deployment, ingress_lookup, unidler):
     ingress = ingress_lookup[(
-        deployment.metadata.name, deployment.metadata.namespace)]
+        deployment.metadata.labels['app'], deployment.metadata.namespace)]
 
     idler.add_host_rule(unidler, ingress)
 


### PR DESCRIPTION
This looks up the ingress by app label, to support jupyter-lab deployments which
call their ingress object something that doesn't match the deployment name.
Looking up by the app label is safe because this is a required label for tools
and is used to show the app name in the cpanel so we can be sure that all tools
will have an app label.