### PR TITLE
Fix an error in patching the Kubernetes service

### DIFF
--- a/idler.py
+++ b/idler.py
@@ -183,7 +183,7 @@ class Service(object):
         client.CoreV1Api().patch_namespaced_service(
             name=self.name,
             namespace=self.namespace,
-            body=json.dumps(patch))
+            body=list(patch))
 
     def redirect_to_unidler(self):
         self.patch(
@@ -196,11 +196,20 @@ class Service(object):
                 "path": "/spec/externalName",
                 "value": UNIDLER_SERVICE_HOST},
             {
-                "op": "remove",
-                "path": "/spec/ports"},
+                "op": "replace",
+                "path": "/spec/ports",
+                "value": [
+                    {
+                        "name": "http",
+                        "port": 80
+                    }
+                ]},
             {
                 "op": "remove",
-                "path": "/spec/selector"})
+                "path": "/spec/selector"},
+            {
+                "op": "remove",
+                "path": "/spec/clusterIP"})
 
 
 def zero_replicas(deployment):

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -160,7 +160,7 @@ def test_idle_deployments(client, deployment, env, metrics):
     core_api.patch_namespaced_service.assert_called_with(
         name=deployment.metadata.name,
         namespace=deployment.metadata.namespace,
-        body=json.dumps([
+        body=[
             {
                 "op": "replace",
                 "path": "/spec/type",
@@ -170,11 +170,20 @@ def test_idle_deployments(client, deployment, env, metrics):
                 "path": "/spec/externalName",
                 "value": UNIDLER_SERVICE_HOST},
             {
-                "op": "remove",
-                "path": "/spec/ports"},
+                "op": "replace",
+                "path": "/spec/ports",
+                "value": [
+                    {
+                        "port": 80,
+                        "name": "http"
+                    }
+                ]},
             {
                 "op": "remove",
-                "path": "/spec/selector"}]))
+                "path": "/spec/selector"},
+            {
+                "op": "remove",
+                "path": "/spec/clusterIP"}])
 
 
 def test_eligible_deployments(client, env):


### PR DESCRIPTION
* `patch_namespaced_service` takes an object body, not a JSON string
* ExternalName Services require a `port`