### PR TITLE
Housekeeping of env vars, defaults and annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -100,6 +101,7 @@ ENV/
 # mypy
 .mypy_cache/
 
-# intellij
+# Editors
 .idea/
 *.iml
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update && apk add --virtual build-dependencies build-base gcc libffi-dev
 
 ADD requirements.txt requirements.txt
 RUN pip install -U pip && pip install -r requirements.txt
+RUN apk del build-dependencies
 
 ADD idler.py idler.py
 ADD metrics_api.py metrics_api.py
@@ -24,5 +25,3 @@ ADD test test
 RUN pytest test
 
 FROM base
-
-RUN apk del build-dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6.8-alpine AS base
 
-MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
+LABEL maintainers="andy.driver@digital.justice.gov.uk,aldo.giambelluca@digital.justice.gov.uk"
 
 WORKDIR /home/idler
 RUN apk update && apk add --virtual build-dependencies build-base gcc libffi-dev openssl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,17 @@ FROM python:3.6.8-alpine AS base
 LABEL maintainers="andy.driver@digital.justice.gov.uk,aldo.giambelluca@digital.justice.gov.uk"
 
 WORKDIR /home/idler
-RUN apk update && apk add --virtual build-dependencies build-base gcc libffi-dev openssl-dev
 
 ADD requirements.txt requirements.txt
-RUN pip install -U pip && pip install -r requirements.txt
-RUN apk del build-dependencies
+RUN apk update && \
+    apk add --virtual build-dependencies build-base gcc libffi-dev openssl-dev && \
+    pip install -U pip && \
+    pip install -r requirements.txt && \
+    apk del build-dependencies
 
 COPY idler.py metrics_api.py ./
 
 CMD ["python", "idler.py"]
-
 
 FROM base AS test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4-alpine AS base
+FROM python:3.6.8-alpine AS base
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
+# Stage: base
 FROM python:3.6.8-alpine AS base
 
 LABEL maintainers="andy.driver@digital.justice.gov.uk,aldo.giambelluca@digital.justice.gov.uk"
 
 WORKDIR /home/idler
+
+RUN adduser -D -u 4242 idler
 
 ADD requirements.txt requirements.txt
 RUN apk update && \
@@ -12,16 +15,21 @@ RUN apk update && \
     apk del build-dependencies
 
 COPY idler.py metrics_api.py ./
+RUN chown -R idler:idler .
 
 CMD ["python", "idler.py"]
 
+
+# Stage: test
 FROM base AS test
 
 COPY test/requirements.txt test/
 RUN pip install -r test/requirements.txt
 
 COPY test test/
-
 RUN pytest test
 
+
+# Stage: final
 FROM base
+USER idler

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,17 @@ ADD requirements.txt requirements.txt
 RUN pip install -U pip && pip install -r requirements.txt
 RUN apk del build-dependencies
 
-ADD idler.py idler.py
-ADD metrics_api.py metrics_api.py
+COPY idler.py metrics_api.py ./
 
 CMD ["python", "idler.py"]
 
 
 FROM base AS test
 
-ADD test/requirements.txt test/
+COPY test/requirements.txt test/
 RUN pip install -r test/requirements.txt
 
-ADD test test
+COPY test test/
 
 RUN pytest test
 

--- a/idler.py
+++ b/idler.py
@@ -29,15 +29,16 @@ log_handler.setFormatter(log_formatter)
 log.addHandler(log_handler)
 
 
-ACTIVE_INSTANCE_CPU_PERCENTAGE = 90
+
+CPU_ACTIVITY_THRESHOLD = 90
 try:
-    ACTIVE_INSTANCE_CPU_PERCENTAGE = int(os.environ.get(
-        'RSTUDIO_ACTIVITY_CPU_THRESHOLD', 90))
+    CPU_ACTIVITY_THRESHOLD = int(os.environ.get(
+        'CPU_ACTIVITY_THRESHOLD', CPU_ACTIVITY_THRESHOLD))
     log.debug(
-        f'RSTUDIO_ACTIVITY_CPU_THRESHOLD={ACTIVE_INSTANCE_CPU_PERCENTAGE}%')
+        f'CPU_ACTIVITY_THRESHOLD={CPU_ACTIVITY_THRESHOLD}%')
 except ValueError:
     log.warning(
-        'Invalid value for RSTUDIO_ACTIVITY_CPU_THRESHOLD, using default')
+        f'Invalid value for CPU_ACTIVITY_THRESHOLD, using default ({CPU_ACTIVITY_THRESHOLD}%)')
 
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
@@ -95,7 +96,7 @@ def eligible_deployments():
 
 
 def label_selector():
-    label_selector = os.environ.get('LABEL_SELECTOR', 'app=rstudio')
+    label_selector = os.environ.get('LABEL_SELECTOR', 'mojanalytics.xyz/idleable=true')
     log.debug(f'LABEL_SELECTOR="{label_selector}"')
     if label_selector:
         label_selector = ',' + label_selector
@@ -113,7 +114,7 @@ def should_idle(deployment):
 
     log.debug(f'{key}: Using {usage}% of CPU')
 
-    if usage > ACTIVE_INSTANCE_CPU_PERCENTAGE:
+    if usage > CPU_ACTIVITY_THRESHOLD:
         log.info(f'{key}: Not idling as using {usage}% of CPU')
         return False
 

--- a/idler.py
+++ b/idler.py
@@ -43,10 +43,8 @@ except ValueError:
     log.warning(
         f'Invalid value for CPU_ACTIVITY_THRESHOLD, using default ({CPU_ACTIVITY_THRESHOLD}%)')
 
-LABEL_SELECTOR = os.environ.get('LABEL_SELECTOR', 'mojanalytics.xyz/idleable=true')
+LABEL_SELECTOR = os.environ.get('LABEL_SELECTOR', 'mojanalytics.xyz/idleable=true').strip()
 log.debug(f'LABEL_SELECTOR="{LABEL_SELECTOR}"')
-if LABEL_SELECTOR:
-    LABEL_SELECTOR = ',' + LABEL_SELECTOR
 
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
@@ -76,7 +74,7 @@ def get_key(pod_or_deployment):
 
 def build_metrics_lookup():
     metrics = client.MetricsV1beta1Api().list_pod_metrics_for_all_namespaces(
-        label_selector=f'!{IDLED}{LABEL_SELECTOR}')
+        label_selector=LABEL_SELECTOR)
 
     for pod_metrics in metrics.items:
         pod_name = pod_metrics.metadata.name
@@ -89,7 +87,7 @@ def build_metrics_lookup():
 
 def build_pods_lookup():
     pods = client.CoreV1Api().list_pod_for_all_namespaces(
-        label_selector=f'!{IDLED}{LABEL_SELECTOR}')
+        label_selector=LABEL_SELECTOR)
     for pod in pods.items:
         pods_lookup[(pod.metadata.name, pod.metadata.namespace)] = pod
 
@@ -100,8 +98,12 @@ def build_lookups():
 
 
 def eligible_deployments():
+    selector = f"!{IDLED}"
+    if LABEL_SELECTOR:
+        selector = f"{selector},{LABEL_SELECTOR}"
+
     return client.AppsV1beta1Api().list_deployment_for_all_namespaces(
-        label_selector=f'!{IDLED}{LABEL_SELECTOR}').items
+        label_selector=selector).items
 
 
 def should_idle(deployment):

--- a/idler.py
+++ b/idler.py
@@ -1,7 +1,7 @@
 """
-Idles an application to save resources.
+Idles applications to save resources.
 
-Idling is performed by scaling down its deployment to zero replicas (no pods
+Idling is performed by scaling down a deployment to zero replicas (no pods
 running).
 
 Only apps with the given label (`LABEL_SELECTOR`) and that are not using more

--- a/idler.py
+++ b/idler.py
@@ -144,7 +144,7 @@ def avg_cpu_percent(deployment):
     try:
         metrics = metrics_lookup[key]
     except KeyError as e:
-        log.warning(f'{key}: Metrics not found, pod may be unhealthy.')
+        log.warning(f'{key}: Metrics not found, pod may be unhealthy. Assuming 0% CPU usage.')
         return 0
 
     usage = 0
@@ -172,7 +172,7 @@ def mark_idled(deployment):
     deployment.metadata.labels[IDLED] = 'true'
     timestamp = datetime.now(timezone.utc).isoformat(timespec='seconds')
     deployment.metadata.annotations[IDLED_AT] = timestamp
-    deployment.metadata.annotations[REPLICAS_WHEN_UNIDLED] = deployment.spec.replicas
+    deployment.metadata.annotations[REPLICAS_WHEN_UNIDLED] = str(deployment.spec.replicas)
 
 
 class Service(object):

--- a/idler.py
+++ b/idler.py
@@ -1,8 +1,12 @@
 """
-Checks all RStudio deployments and idles those matching a kubernetes label
-selector.
-The label selector can be overridden by setting the LABEL_SELECTOR environment
-variable.
+Idles an application to save resources.
+
+Idling is performed by scaling down its deployment to zero replicas (no pods
+running).
+
+Only apps with the given label (`LABEL_SELECTOR`) and that are not using more
+than the given CPU threshold (`CPU_ACTIVITY_THRESHOLD`) will be idled.
+
 See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 for label selector syntax.
 """

--- a/idler.py
+++ b/idler.py
@@ -46,6 +46,7 @@ if LABEL_SELECTOR:
 
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
+REPLICAS_WHEN_UNIDLED = 'mojanalytics.xyz/replicas-when-unidled'
 SERVICE_TYPE_EXTERNAL_NAME = "ExternalName"
 UNIDLER_SERVICE_HOST = "unidler.default.svc.cluster.local"
 
@@ -162,10 +163,10 @@ def idle(deployment):
 
 
 def mark_idled(deployment):
-    timestamp = datetime.now(timezone.utc).isoformat(timespec='seconds')
     deployment.metadata.labels[IDLED] = 'true'
-    deployment.metadata.annotations[IDLED_AT] = (
-        f'{timestamp},{deployment.spec.replicas}')
+    timestamp = datetime.now(timezone.utc).isoformat(timespec='seconds')
+    deployment.metadata.annotations[IDLED_AT] = timestamp
+    deployment.metadata.annotations[REPLICAS_WHEN_UNIDLED] = deployment.spec.replicas
 
 
 class Service(object):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-pytest==3.8.2
-hypothesis==3.75.4
+pytest==4.4.0
+hypothesis==4.14.2

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -207,10 +207,7 @@ def test_eligible_deployments(client, env):
     ('', f'!{IDLED}'),
 ])
 def test_label_selector(client, env, label_selector, expected):
-    if label_selector:
-        idler.LABEL_SELECTOR = f",{label_selector}"
-    else:
-        idler.LABEL_SELECTOR = label_selector
+    idler.LABEL_SELECTOR = label_selector
 
     idler.eligible_deployments()
 

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -207,13 +207,12 @@ def test_eligible_deployments(client, env):
     ('', f'!{IDLED}'),
 ])
 def test_label_selector(client, env, label_selector, expected):
-    idler.LABEL_SELECTOR = label_selector
+    with patch('idler.LABEL_SELECTOR', label_selector):
+        idler.eligible_deployments()
 
-    idler.eligible_deployments()
-
-    api = client.AppsV1beta1Api.return_value
-    api.list_deployment_for_all_namespaces.assert_called_with(
-        label_selector=expected)
+        api = client.AppsV1beta1Api.return_value
+        api.list_deployment_for_all_namespaces.assert_called_with(
+            label_selector=expected)
 
 
 def test_should_idle(deployment, env, metrics):

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -248,7 +248,7 @@ def test_avg_cpu_percent(
 
 
 def test_mark_idled(deployment, current_time):
-    expected_replicas = deployment.spec.replicas
+    expected_replicas = str(deployment.spec.replicas)
 
     idler.mark_idled(deployment)
 


### PR DESCRIPTION
Possibly breaking 3rd party:
- [changed](https://github.com/ministryofjustice/analytics-platform-idler/commit/ed0d16ed5e0436eaa6cef5e9405a29c339db3a3d#diff-225132354aa2a9f4d7ecebb48833c06bR99) default for `LABEL_SELECTOR` from `app=rstudio` to `mojanalytics.xyz/idleable=true` which is what we use in the config (breaking if they don't set this env var and they rely on default)

Breaking:
- [renamed](https://github.com/ministryofjustice/analytics-platform-idler/commit/ed0d16ed5e0436eaa6cef5e9405a29c339db3a3d#diff-225132354aa2a9f4d7ecebb48833c06bR36) env var `RSTUDIO_ACTIVITY_CPU_THRESHOLD` => `CPU_ACTIVITY_THRESHOLD`, again it's not just about RStudio anymore. Also this is consistent to [what we have in the Helm chart](https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/master/charts/idler/values.yaml#L21). (helm chart need updating to set the right env. If not it would default to 90% so not that breaking really.)
- [Stop](https://github.com/ministryofjustice/analytics-platform-idler/commit/a37ca72e7b40153b6d9e0a48646be8eda704aec1#diff-225132354aa2a9f4d7ecebb48833c06bR168) having the number of replicas in the `idled-at` annotation, this annotation will now only have the time when the app was idled. Simple and clear. (unidler or whoever uses this needs to change. **NOTE**: unidler is already robust enough to handle when this is not there or it's not valid)

Non-breaking:
- [added](https://github.com/ministryofjustice/analytics-platform-idler/commit/a37ca72e7b40153b6d9e0a48646be8eda704aec1#diff-225132354aa2a9f4d7ecebb48833c06b) `replicas-when-unidled` annotation with the sole responsibility of keeping the number of replicas desired at the time of idling.
- [got rid](https://github.com/ministryofjustice/analytics-platform-idler/commit/0b879b1196aa2d8ad31b415ebbf537c656c0858e) of unnecessary method `label_selector()` and moved reading of `LABEL_SELECTOR` env var at top of file (read inputs at the beginning of file/methods improves readability and it makes easier for someone to know what env variables are involved in the idling process)
- [updated](https://github.com/ministryofjustice/analytics-platform-idler/pull/68/commits/17b4c9267593a22a27373d43bce825b02a428e87) header comment.
- [bumped Python version](https://github.com/ministryofjustice/analytics-platform-idler/pull/68/commits/2d3e8de1e45bd8cef7e735941d5e53a3aa9bc73d) from `3.6.4` => `3.6.8`
- various `Dockerfile` improvements/cleanups:
  - [don't run as root](https://github.com/ministryofjustice/analytics-platform-idler/pull/68/commits/3a1705154c3cb2f3e6f5b3a8815b293175919326)
  - use `LABEL` instead of deprecated `MAINTAINER` command
  - use `COPY` instead of `ADD` (which can be sneaky)
  - grouped commands to install dependencies into a single `RUN` command/layer
- [updated](https://github.com/ministryofjustice/analytics-platform-idler/pull/68/commits/16791458010020efe9c48fb2378d0d8decadde18) test dependencies