### PR TITLE
Patch Service using strategic merge instead of JSONPatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/python:3.6.4
+
+    steps:
+      - checkout
+
+      - run:
+          name: create/activate virtual environment
+          command: |
+            python3 -m venv venv
+
+
+      - run:
+          name: install dependencies
+          command: |
+            . venv/bin/activate
+            pip install -r requirements.txt
+            pip install -r test/requirements.txt
+
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,5 +28,4 @@ jobs:
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
-            pytest
+            venv/bin/pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base
-FROM python:3.6.8-alpine AS base
+FROM python:3.7-alpine AS base
 
 LABEL maintainers="andy.driver@digital.justice.gov.uk,aldo.giambelluca@digital.justice.gov.uk"
 

--- a/idler.py
+++ b/idler.py
@@ -210,39 +210,30 @@ class Service(object):
         self.service = client.CoreV1Api().read_namespaced_service(
             name, namespace)
 
-    def patch(self, *patch):
+    def patch(self, patch):
         client.CoreV1Api().patch_namespaced_service(
             name=self.name,
             namespace=self.namespace,
-            body=list(patch))
+            body=patch,
+        )
 
     def redirect_to_unidler(self):
-        self.patch(
-            {
-                "op": "replace",
-                "path": "/spec/type",
-                "value": SERVICE_TYPE_EXTERNAL_NAME},
-            {
-                "op": "add",
-                "path": "/spec/externalName",
-                "value": UNIDLER_SERVICE_HOST},
-            {
-                "op": "replace",
-                "path": "/spec/ports",
-                "value": [
+        self.patch({
+            "spec": {
+                "selector": None, # remove
+                "clusterIP": None, # remove
+                "type": SERVICE_TYPE_EXTERNAL_NAME,
+                "externalName": UNIDLER_SERVICE_HOST,
+                "ports": [
                     {
                         "name": "http",
                         "port": 80,
                         "protocol": "TCP",
                         "targetPort": 80
                     }
-                ]},
-            {
-                "op": "remove",
-                "path": "/spec/selector"},
-            {
-                "op": "remove",
-                "path": "/spec/clusterIP"})
+                ]
+            }
+        })
 
 
 def zero_replicas(deployment):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-kubernetes==7.0.0
+# See Compatibility matrix:
+#   https://github.com/kubernetes-client/python#compatibility
+kubernetes==9.0.0

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -164,32 +164,23 @@ def test_idle_deployments(client, deployment, env, metrics):
     core_api.patch_namespaced_service.assert_called_with(
         name=deployment.metadata.name,
         namespace=deployment.metadata.namespace,
-        body=[
-            {
-                "op": "replace",
-                "path": "/spec/type",
-                "value": SERVICE_TYPE_EXTERNAL_NAME},
-            {
-                "op": "add",
-                "path": "/spec/externalName",
-                "value": UNIDLER_SERVICE_HOST},
-            {
-                "op": "replace",
-                "path": "/spec/ports",
-                "value": [
+        body={
+            "spec": {
+                "selector": None, # remove
+                "clusterIP": None, # remove
+                "type": SERVICE_TYPE_EXTERNAL_NAME,
+                "externalName": UNIDLER_SERVICE_HOST,
+                "ports": [
                     {
                         "name": "http",
                         "port": 80,
                         "protocol": "TCP",
                         "targetPort": 80
                     }
-                ]},
-            {
-                "op": "remove",
-                "path": "/spec/selector"},
-            {
-                "op": "remove",
-                "path": "/spec/clusterIP"}])
+                ]
+            }
+        }
+    )
 
 
 def test_eligible_deployments(client, env):

--- a/test/test_idler.py
+++ b/test/test_idler.py
@@ -146,20 +146,11 @@ def pods_lookup(pod):
         yield cache
 
 
-def test_idle_deployments(client, deployment, env, metrics):
+def test_idle_deployments(client, deployment, env, metrics, current_time):
     core_api = client.CoreV1Api.return_value
     apps_api = client.AppsV1beta1Api.return_value
 
     idler.idle_deployments()
-
-    apps_api.patch_namespaced_deployment.assert_called_with(
-        deployment.metadata.name,
-        deployment.metadata.namespace,
-        deployment)
-
-    core_api.read_namespaced_service.assert_called_with(
-        deployment.metadata.name,
-        deployment.metadata.namespace)
 
     core_api.patch_namespaced_service.assert_called_with(
         name=deployment.metadata.name,
@@ -179,6 +170,25 @@ def test_idle_deployments(client, deployment, env, metrics):
                     }
                 ]
             }
+        }
+    )
+
+    apps_api.patch_namespaced_deployment.assert_called_with(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        body={
+            "spec": {
+                "replicas": 0
+            },
+            "metadata": {
+                "labels": {
+                    IDLED: "true",
+                },
+                "annotations": {
+                    IDLED_AT: current_time.isoformat(timespec='seconds'),
+                    REPLICAS_WHEN_UNIDLED: "2",
+                },
+            },
         }
     )
 
@@ -236,31 +246,3 @@ def test_avg_cpu_percent(
     key = (deployment.metadata.labels['app'], deployment.metadata.namespace)
     metrics[key] = mock_podmetric(cpu_usage)
     assert idler.avg_cpu_percent(deployment) == expected
-
-
-def test_mark_idled(deployment, current_time):
-    expected_replicas = str(deployment.spec.replicas)
-
-    idler.mark_idled(deployment)
-
-    assert IDLED in deployment.metadata.labels
-    assert IDLED_AT in deployment.metadata.annotations
-    assert current_time.isoformat(timespec='seconds') == deployment.metadata.annotations[IDLED_AT]
-    assert expected_replicas == deployment.metadata.annotations[REPLICAS_WHEN_UNIDLED]
-
-
-def test_zero_replicas(deployment):
-    idler.zero_replicas(deployment)
-
-    assert deployment.spec.replicas == 0
-
-
-def test_write_changes(client, deployment):
-    idler.write_changes(deployment)
-
-    api = client.AppsV1beta1Api.return_value
-    api.patch_namespaced_deployment.assert_called_with(
-        deployment.metadata.name,
-        deployment.metadata.namespace,
-        deployment
-    )


### PR DESCRIPTION
JSONPatch is been a source of troubles. Specifically because of the
    fact that the specification says that the patch should not work
    when trying to remove a key which is not present.
    Even "worse" the whole patch will be rejected so none of the changes
    would be applied.

Basically a JSONPatch are not applied in an idempotent way as we thought.

Strategic merge seems more predictable/declarative and it doesn't blow up
    when the key is not present already.

**NOTE**: To remove a key from a dictionary/map it's possible to set that
    key to `null`.


#### Also: Better error handling
Handle all exceptions and log an error instead of causing an exception
    to stop the loop and prevent idling of subsequent deployments.

The list of Deployments which were not idled is then shown at the end.
    If if was not possible to idle any of the Deployments the idler also
    exits with a non-zero value so that the job is marked as failed as it
    should in this case.

#### Also: Upgraded kubernetes module to version 9
This is supporting up to kubernetes 1.13 and it's retrocompatible.

See [Compatibility matrix](https://github.com/kubernetes-client/python#compatibility)


**Part of ticket**: https://trello.com/c/vr4LPcde/241-investigate-fix-idling-unidling-problems-caused-by-k8s-cluster-upgrade-new-version-of-k8s